### PR TITLE
Add support for tool calling

### DIFF
--- a/examples/multiple_agents.py
+++ b/examples/multiple_agents.py
@@ -12,8 +12,8 @@ mistral: LLMOptions = {
     "api_base": "http://localhost:11434",
 }
 
-llama2: LLMOptions = {
-    "model": "ollama/llama2",
+llama3: LLMOptions = {
+    "model": "ollama/llama3.1",
     "temperature": 0.7,
     "api_base": "http://localhost:11434",
 }
@@ -33,7 +33,7 @@ def store_conversation():
     customer = ChatAgent(
         system="You are a customer at a shop. Speak concisely and clearly.",
         character="customer",
-        llm_options=llama2,
+        llm_options=llama3,
         ai_text_color="bright_green",
     )
     runs = 0

--- a/examples/tool_calling.py
+++ b/examples/tool_calling.py
@@ -1,0 +1,91 @@
+import json
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+from simple_ai_agents.chat_session import ChatLLMSession
+from simple_ai_agents.models import LLMOptions, Tool
+
+load_dotenv()
+
+openai: LLMOptions = {"model": "gpt-4o-mini", "temperature": 0.7}
+github: LLMOptions = {
+    "model": "github/gpt-4o-mini",
+}
+
+
+def get_current_weather(location, unit="fahrenheit"):
+    """
+    Get the current weather in a given location
+
+    Args:
+        location (str): The city and state, e.g. San Francisco, CA
+        unit (str): The unit of the temperature, either celsius or fahrenheit
+    """
+    if "tokyo" in location.lower():
+        return json.dumps({"location": "Tokyo", "temperature": "10", "unit": "celsius"})
+    elif "san francisco" in location.lower():
+        return json.dumps(
+            {"location": "San Francisco", "temperature": "72", "unit": "fahrenheit"}
+        )
+    elif "paris" in location.lower():
+        return json.dumps({"location": "Paris", "temperature": "22", "unit": "celsius"})
+    else:
+        return json.dumps({"location": location, "temperature": "unknown"})
+
+
+weather_tool_schema = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA",
+                },
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location"],
+        },
+    },
+}
+
+
+class Weather(BaseModel):
+    """Get the current weather in a given location"""
+
+    location: str = Field(description="Location of the weather")
+    unit: str = Field(description="Unit of the temperature")
+
+
+def run():
+    sess = ChatLLMSession()
+    response = sess.gen(
+        "What's the weather like in San Francisco",
+        llm_options=github,
+        tools=[
+            # Tool(tool_model=weather_tool_schema, function=get_current_weather),
+            # Tool(tool_model=Weather, function=get_current_weather),
+            Tool(function=get_current_weather),
+        ],
+        tool_choice="auto",
+    )
+    print(response)
+    # Tool calling also works with stream method
+    # stream = sess.stream(
+    #     "What's the weather like in San Francisco",
+    #     llm_options=github,
+    #     tools=[
+    #         Tool(tool_model=weather_tool_schema, function=get_current_weather),
+    #     ],
+    #     tool_choice="auto",
+    # )
+    # for chunk in stream:
+    #     print(chunk["delta"])
+
+
+if __name__ == "__main__":
+    run()

--- a/simple_ai_agents/chat_agent.py
+++ b/simple_ai_agents/chat_agent.py
@@ -210,6 +210,8 @@ class ChatAgent(BaseModel):
             stream = sess.stream(
                 prompt,
                 system=system,
+                tools=tools if tools else self.tools,
+                tool_choice=tool_choice if tool_choice else self.tool_choice,
                 save_messages=save_messages,
                 llm_options=llm_options,
             )
@@ -232,6 +234,8 @@ class ChatAgent(BaseModel):
         prompt: Union[str, Any],
         id: Optional[Union[str, UUID]] = None,
         system: Optional[str] = None,
+        tools: Optional[list[Tool]] = None,
+        tool_choice: Optional[str | dict[str, Any]] = None,
         save_messages: Optional[bool] = None,
         llm_options: Optional[LLMOptions] = None,
     ):
@@ -242,6 +246,8 @@ class ChatAgent(BaseModel):
         return sess.stream(
             prompt,
             system=system,
+            tools=tools if tools else self.tools,
+            tool_choice=tool_choice if tool_choice else self.tool_choice,
             save_messages=save_messages,
             llm_options=llm_options,
         )
@@ -466,6 +472,8 @@ class ChatAgentAsync(ChatAgent):
         prompt: Union[str, Any],
         id: Optional[Union[str, UUID]] = None,
         system: Optional[str] = None,
+        tools: Optional[list[Tool]] = None,
+        tool_choice: Optional[str | dict[str, Any]] = None,
         save_messages: Optional[bool] = None,
         llm_options: Optional[LLMOptions] = None,
     ):
@@ -473,6 +481,8 @@ class ChatAgentAsync(ChatAgent):
         return sess.stream_async(
             prompt,
             system=system,
+            tools=tools if tools else self.tools,
+            tool_choice=tool_choice if tool_choice else self.tool_choice,
             save_messages=save_messages,
             llm_options=llm_options,
         )

--- a/simple_ai_agents/chat_session.py
+++ b/simple_ai_agents/chat_session.py
@@ -610,10 +610,10 @@ class ChatLLMSession(ChatSession):
         """
         # Use tool.tool_model["function"]["name"] instead of too.function.__name__
         # since returned response is based on schema and there might be a name mismatch
-        print(tool_calls)
         available_functions = {
             tool.tool_model["function"]["name"]: tool.function for tool in tools  # type: ignore
         }
+        tool_history = [response_message]
         for tool_call in tool_calls:
             function_name = tool_call["function"]["name"]
             function_args = json.loads(tool_call["function"]["arguments"])
@@ -629,5 +629,5 @@ class ChatLLMSession(ChatSession):
                 "name": function_name,
                 "content": function_response,
             }
-            tool_history = [response_message, function_message]
+            tool_history.append(function_message)
         return tool_history

--- a/simple_ai_agents/chat_session.py
+++ b/simple_ai_agents/chat_session.py
@@ -509,7 +509,7 @@ class ChatLLMSession(ChatSession):
         # Use tool.tool_model["function"]["name"] instead of too.function.__name__
         # since returned response is based on schema and there might be a name mismatch
         available_functions = {
-            tool.tool_model["function"]["name"]: tool.function for tool in tools
+            tool.tool_model["function"]["name"]: tool.function for tool in tools  # type: ignore
         }
         for tool_call in tool_calls:
             function_name = tool_call["function"]["name"]

--- a/simple_ai_agents/external.py
+++ b/simple_ai_agents/external.py
@@ -1,0 +1,327 @@
+import inspect
+import textwrap
+from typing import Any, Callable, Optional, Sequence, Union, overload
+
+import pydantic
+from pydantic import BaseModel, create_model
+from pydantic.fields import FieldInfo
+from typing_extensions import Annotated, get_args, get_origin
+
+
+def create_schema_from_function(
+    model_name: str,
+    func: Callable,
+    *,
+    filter_args: Optional[Sequence[str]] = None,
+    parse_docstring: bool = False,
+    error_on_invalid_docstring: bool = False,
+    include_injected: bool = True,
+) -> type[BaseModel]:
+    """Create a pydantic schema from a function's signature.
+    Adapted from: https://python.langchain.com/api_reference/_modules/langchain_core/tools/base.html
+
+    Args:
+        model_name: Name to assign to the generated pydantic schema.
+        func: Function to generate the schema from.
+        filter_args: Optional list of arguments to exclude from the schema.
+            Defaults to FILTERED_ARGS.
+        parse_docstring: Whether to parse the function's docstring for descriptions
+            for each argument. Defaults to False.
+        error_on_invalid_docstring: if ``parse_docstring`` is provided, configure
+            whether to raise ValueError on invalid Google Style docstrings.
+            Defaults to False.
+        include_injected: Whether to include injected arguments in the schema.
+            Defaults to True, since we want to include them in the schema
+            when *validating* tool inputs.
+
+    Returns:
+        A pydantic model with the same arguments as the function.
+    """
+    sig = inspect.signature(func)
+    fields = {}
+
+    for name, param in sig.parameters.items():
+        if filter_args and name in filter_args:
+            continue
+
+        # Set default or Required type in the schema
+        if param.default is param.empty:
+            default = ...
+        else:
+            default = param.default
+
+        annotation = param.annotation if param.annotation is not param.empty else Any
+        fields[name] = (annotation, default)
+    model = create_model(model_name, **fields)
+    if func.__qualname__ and "." in func.__qualname__:
+        # Then it likely belongs in a class namespace
+        in_class = True
+    else:
+        in_class = False
+
+    has_args = False
+    has_kwargs = False
+
+    for param in sig.parameters.values():
+        if param.kind == param.VAR_POSITIONAL:
+            has_args = True
+        elif param.kind == param.VAR_KEYWORD:
+            has_kwargs = True
+
+    inferred_model = model
+    FILTERED_ARGS = ("run_manager", "callbacks")
+
+    if filter_args:
+        filter_args_ = filter_args
+    else:
+        # Handle classmethods and instance methods
+        existing_params: list[str] = list(sig.parameters.keys())
+        if existing_params and existing_params[0] in ("self", "cls") and in_class:
+            filter_args_ = [existing_params[0]] + list(FILTERED_ARGS)
+        else:
+            filter_args_ = list(FILTERED_ARGS)
+
+        for existing_param in existing_params:
+            if not include_injected and _is_injected_arg_type(
+                sig.parameters[existing_param].annotation
+            ):
+                filter_args_.append(existing_param)  # type: ignore
+
+    description, arg_descriptions = _infer_arg_descriptions(
+        func,
+        parse_docstring=parse_docstring,
+        error_on_invalid_docstring=error_on_invalid_docstring,
+    )
+    # Pydantic adds placeholder virtual fields we need to strip
+    valid_properties = []
+    for field in get_fields(inferred_model):
+        if not has_args:
+            if field == "args":
+                continue
+        if not has_kwargs:
+            if field == "kwargs":
+                continue
+
+        if field == "v__duplicate_kwargs":  # Internal pydantic field
+            continue
+
+        if field not in filter_args_:
+            valid_properties.append(field)
+
+    return _create_subset_model_v2(
+        model_name,
+        inferred_model,
+        list(valid_properties),
+        descriptions=arg_descriptions,
+        fn_description=description,
+    )
+
+
+class _SchemaConfig:
+    """Configuration for the pydantic model.
+
+    This is used to configure the pydantic model created from
+    a function's signature.
+
+    Parameters:
+        extra: Whether to allow extra fields in the model.
+        arbitrary_types_allowed: Whether to allow arbitrary types in the model.
+            Defaults to True.
+    """
+
+    extra: str = "forbid"
+    arbitrary_types_allowed: bool = True
+
+
+@overload
+def get_fields(model: type[BaseModel]) -> dict[str, FieldInfo]: ...
+
+
+@overload
+def get_fields(model: BaseModel) -> dict[str, FieldInfo]: ...
+
+
+def get_fields(
+    model: Union[
+        BaseModel,
+        type[BaseModel],
+    ],
+) -> dict[str, FieldInfo]:
+    """Get the field names of a Pydantic model."""
+    if hasattr(model, "model_fields"):
+        return model.model_fields  # type: ignore
+
+    elif hasattr(model, "__fields__"):
+        return model.__fields__  # type: ignore
+    else:
+        raise TypeError(f"Expected a Pydantic model. Got {type(model)}")
+
+
+class InjectedToolArg:
+    """Annotation for a Tool arg that is **not** meant to be generated by a model."""
+
+
+def _is_injected_arg_type(type_: type) -> bool:
+    return any(
+        isinstance(arg, InjectedToolArg)
+        or (isinstance(arg, type) and issubclass(arg, InjectedToolArg))
+        for arg in get_args(type_)[1:]
+    )
+
+
+def _infer_arg_descriptions(
+    fn: Callable,
+    *,
+    parse_docstring: bool = False,
+    error_on_invalid_docstring: bool = False,
+) -> tuple[str, dict]:
+    """Infer argument descriptions from a function's docstring."""
+    if hasattr(inspect, "get_annotations"):
+        # This is for python < 3.10
+        annotations = inspect.get_annotations(fn)  # type: ignore
+    else:
+        annotations = getattr(fn, "__annotations__", {})
+    if parse_docstring:
+        description, arg_descriptions = _parse_python_function_docstring(
+            fn, annotations, error_on_invalid_docstring=error_on_invalid_docstring
+        )
+    else:
+        description = inspect.getdoc(fn) or ""
+        arg_descriptions = {}
+    if parse_docstring:
+        _validate_docstring_args_against_annotations(arg_descriptions, annotations)
+    for arg, arg_type in annotations.items():
+        if arg in arg_descriptions:
+            continue
+        if desc := _get_annotation_description(arg_type):
+            arg_descriptions[arg] = desc
+    return description, arg_descriptions
+
+
+def _parse_python_function_docstring(
+    function: Callable, annotations: dict, error_on_invalid_docstring: bool = False
+) -> tuple[str, dict]:
+    """Parse the function and argument descriptions from the docstring of a function.
+
+    Assumes the function docstring follows Google Python style guide.
+    """
+    docstring = inspect.getdoc(function)
+    return _parse_google_docstring(
+        docstring,
+        list(annotations),
+        error_on_invalid_docstring=error_on_invalid_docstring,
+    )
+
+
+def _validate_docstring_args_against_annotations(
+    arg_descriptions: dict, annotations: dict
+) -> None:
+    """Raise error if docstring arg is not in type annotations."""
+    for docstring_arg in arg_descriptions:
+        if docstring_arg not in annotations:
+            raise ValueError(
+                f"Arg {docstring_arg} in docstring not found in function signature."
+            )
+
+
+def _is_annotated_type(typ: type[Any]) -> bool:
+    return get_origin(typ) is Annotated
+
+
+def _get_annotation_description(arg_type: type) -> str | None:
+    if _is_annotated_type(arg_type):
+        annotated_args = get_args(arg_type)
+        for annotation in annotated_args[1:]:
+            if isinstance(annotation, str):
+                return annotation
+    return None
+
+
+def _parse_google_docstring(
+    docstring: Optional[str],
+    args: list[str],
+    *,
+    error_on_invalid_docstring: bool = False,
+) -> tuple[str, dict]:
+    """Parse the function and argument descriptions from the docstring of a function.
+
+    Assumes the function docstring follows Google Python style guide.
+    """
+    if docstring:
+        docstring_blocks = docstring.split("\n\n")
+        if error_on_invalid_docstring:
+            filtered_annotations = {
+                arg for arg in args if arg not in ("run_manager", "callbacks", "return")
+            }
+            if filtered_annotations and (
+                len(docstring_blocks) < 2 or not docstring_blocks[1].startswith("Args:")
+            ):
+                raise ValueError("Found invalid Google-Style docstring.")
+        descriptors = []
+        args_block = None
+        past_descriptors = False
+        for block in docstring_blocks:
+            if block.startswith("Args:"):
+                args_block = block
+                break
+            elif block.startswith("Returns:") or block.startswith("Example:"):
+                # Don't break in case Args come after
+                past_descriptors = True
+            elif not past_descriptors:
+                descriptors.append(block)
+            else:
+                continue
+        description = " ".join(descriptors)
+    else:
+        if error_on_invalid_docstring:
+            raise ValueError("Found invalid Google-Style docstring.")
+        description = ""
+        args_block = None
+    arg_descriptions = {}
+    if args_block:
+        arg = None
+        for line in args_block.split("\n")[1:]:
+            if ":" in line:
+                arg, desc = line.split(":", maxsplit=1)
+                arg_descriptions[arg.strip()] = desc.strip()
+            elif arg:
+                arg_descriptions[arg.strip()] += " " + line.strip()
+    return description, arg_descriptions
+
+
+def _create_subset_model_v2(
+    name: str,
+    model: type[pydantic.BaseModel],
+    field_names: list[str],
+    *,
+    descriptions: Optional[dict] = None,
+    fn_description: Optional[str] = None,
+) -> type[pydantic.BaseModel]:
+    """Create a pydantic model with a subset of the model fields."""
+    from pydantic import create_model
+    from pydantic.fields import FieldInfo
+
+    descriptions_ = descriptions or {}
+    fields = {}
+    for field_name in field_names:
+        field = model.model_fields[field_name]  # type: ignore
+        description = descriptions_.get(field_name, field.description)
+        field_info = FieldInfo(description=description, default=field.default)
+        if field.metadata:
+            field_info.metadata = field.metadata
+        fields[field_name] = (field.annotation, field_info)
+    rtn = create_model(name, **fields)  # type: ignore
+
+    # TODO(0.3): Determine if there is a more "pydantic" way to preserve annotations.
+    # This is done to preserve __annotations__ when working with pydantic 2.x
+    # and using the Annotated type with TypedDict.
+    # Comment out the following line, to trigger the relevant test case.
+    selected_annotations = [
+        (name, annotation)
+        for name, annotation in model.__annotations__.items()
+        if name in field_names
+    ]
+
+    rtn.__annotations__ = dict(selected_annotations)
+    rtn.__doc__ = textwrap.dedent(fn_description or model.__doc__ or "")
+    return rtn

--- a/simple_ai_agents/models.py
+++ b/simple_ai_agents/models.py
@@ -35,8 +35,8 @@ class LLMOptions(TypedDict, total=False):
 
 
 class Tool(BaseModel):
-    tool_model: dict[str, Any] | type[BaseModel]
     function: Callable
+    tool_model: Optional[dict[str, Any] | type[BaseModel]] = None
 
 
 class ChatMessage(BaseModel):

--- a/simple_ai_agents/models.py
+++ b/simple_ai_agents/models.py
@@ -35,7 +35,7 @@ class LLMOptions(TypedDict, total=False):
 
 
 class Tool(BaseModel):
-    tool_schema: dict[str, Any]
+    tool_model: dict[str, Any] | type[BaseModel]
     function: Callable
 
 

--- a/simple_ai_agents/models.py
+++ b/simple_ai_agents/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Literal, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Union
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -32,6 +32,11 @@ class LLMOptions(TypedDict, total=False):
     model_list: list
     # For ollama only, see: https://docs.litellm.ai/docs/providers/ollama#example-usage---json-mode
     format: Literal["json"]
+
+
+class Tool(BaseModel):
+    tool_schema: dict[str, Any]
+    function: Callable
 
 
 class ChatMessage(BaseModel):
@@ -77,8 +82,7 @@ class ChatSession(BaseModel):
 
     def add_messages(
         self,
-        user_message: ChatMessage,
-        assistant_message: ChatMessage,
+        messages: List[ChatMessage],
         save_messages: Optional[bool] = None,
     ) -> None:
         # if save_messages is explicitly defined, always use that choice
@@ -87,8 +91,6 @@ class ChatSession(BaseModel):
 
         if to_save:
             if save_messages:
-                self.messages.append(user_message)
-                self.messages.append(assistant_message)
+                self.messages.extend(messages)
         elif self.save_messages:
-            self.messages.append(user_message)
-            self.messages.append(assistant_message)
+            self.messages.extend(messages)

--- a/simple_ai_agents/utils.py
+++ b/simple_ai_agents/utils.py
@@ -6,6 +6,7 @@ from instructor.mode import Mode
 from instructor.process_response import process_response
 from pydantic import BaseModel
 
+from simple_ai_agents.external import create_schema_from_function
 from simple_ai_agents.models import Tool
 
 T_Model = TypeVar("T_Model", bound=BaseModel)
@@ -115,5 +116,10 @@ def format_tool_schema(tools: list[Tool]):
                 response_model=tool.tool_model, mode=Mode.TOOLS
             )
             tool.tool_model = kwargs["tools"][0]
+        elif tool.tool_model is None and callable(tool.function):
+            model = create_schema_from_function(tool.function.__name__, tool.function)
+            _, kwargs = handle_response_model(response_model=model, mode=Mode.TOOLS)
+            tool.tool_model = kwargs["tools"][0]
+
     tool_schemas = [tool.tool_model for tool in tools]
     return tools, tool_schemas

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 
@@ -6,6 +7,7 @@ from dotenv import load_dotenv
 from pydantic import BaseModel
 
 from simple_ai_agents.chat_agent import ChatAgent, ChatAgentAsync
+from simple_ai_agents.models import Tool
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 load_dotenv()
@@ -105,3 +107,22 @@ async def test_chat_agent_async():
     chatbot = ChatAgentAsync()
     response = await chatbot("Hello")
     assert isinstance(response, str)
+
+
+def get_current_weather(location, unit="fahrenheit"):
+    """Get the current weather in a given location"""
+    if "tokyo" in location.lower():
+        return json.dumps({"location": "Tokyo", "temperature": "10", "unit": "celsius"})
+    elif "san francisco" in location.lower():
+        return json.dumps(
+            {"location": "San Francisco", "temperature": "72", "unit": "fahrenheit"}
+        )
+    else:
+        return json.dumps({"location": location, "temperature": "unknown"})
+
+
+def test_chat_agent_with_tools():
+    chatbot = ChatAgent(tools=[Tool(function=get_current_weather)])
+    response = chatbot("Hi, what is the weather in San Francisco?")
+    assert isinstance(response, str)
+    assert "72" in response

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1,0 +1,82 @@
+import json
+
+import pytest
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+from simple_ai_agents.chat_session import ChatLLMSession
+from simple_ai_agents.models import Tool
+
+load_dotenv()
+
+
+def get_current_weather(location, unit="fahrenheit"):
+    """Get the current weather in a given location"""
+    if "tokyo" in location.lower():
+        return json.dumps({"location": "Tokyo", "temperature": "10", "unit": "celsius"})
+    elif "san francisco" in location.lower():
+        return json.dumps(
+            {"location": "San Francisco", "temperature": "72", "unit": "fahrenheit"}
+        )
+    else:
+        return json.dumps({"location": location, "temperature": "unknown"})
+
+
+weather_tool_schema = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA",
+                },
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["location"],
+        },
+    },
+}
+
+
+class Weather(BaseModel):
+    """Get the current weather in a given location"""
+
+    location: str = Field(description="Location of the weather")
+    unit: str = Field(description="Unit of the temperature")
+
+
+@pytest.mark.parametrize(
+    "tools",
+    [
+        [Tool(tool_model=weather_tool_schema, function=get_current_weather)],
+        [Tool(tool_model=Weather, function=get_current_weather)],
+    ],
+)
+def test_gen_with_tool(tools):
+    sess = ChatLLMSession()
+    response = sess.gen(
+        "What's the weather like in San Francisco",
+        tools=tools,
+    )
+    assert "72" in response
+
+
+@pytest.mark.parametrize(
+    "tools",
+    [
+        [Tool(tool_model=weather_tool_schema, function=get_current_weather)],
+        [Tool(tool_model=Weather, function=get_current_weather)],
+    ],
+)
+@pytest.mark.asyncio
+async def test_gen_model_async(tools):
+    sess = ChatLLMSession()
+    response = await sess.gen_async(
+        "What's the weather like in San Francisco",
+        tools=tools,
+    )
+    assert "72" in response

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -54,6 +54,7 @@ class Weather(BaseModel):
     [
         [Tool(tool_model=weather_tool_schema, function=get_current_weather)],
         [Tool(tool_model=Weather, function=get_current_weather)],
+        [Tool(function=get_current_weather)],
     ],
 )
 def test_gen_with_tool(tools):
@@ -70,6 +71,7 @@ def test_gen_with_tool(tools):
     [
         [Tool(tool_model=weather_tool_schema, function=get_current_weather)],
         [Tool(tool_model=Weather, function=get_current_weather)],
+        [Tool(function=get_current_weather)],
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
- `gen` and `gen_async` now supports tool calling!
- Tools can take the form of:
    - Openai json schema and function;
    - Pydantic `BaseModel` and function;
    - Or just a function (in which case the pydantic schema will be derived based on the function typings and docstrings (adapted from Langchain)

Example of Tools
```py
from simple_ai_agents.models import Tool

Tool(tool_model=weather_tool_schema, function=get_current_weather)
Tool(tool_model=Weather, function=get_current_weather)
Tool(function=get_current_weather)
```

See `examples/tool_calling.py` for an example of how to pass tools to a session or agent.