### PR TITLE
Pydantic to text stream

### DIFF
--- a/examples/fastapi_stream.py
+++ b/examples/fastapi_stream.py
@@ -3,12 +3,14 @@ from typing import AsyncGenerator
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
+from litellm import BaseModel, Field
 
 from simple_ai_agents.chat_session import ChatLLMSession
 from simple_ai_agents.models import LLMOptions
+from simple_ai_agents.utils import async_pydantic_to_text_stream
 
 # To run the FastAPI server, execute the following command:
-# fastapi run examples/fastapi_stream.py
+# fastapi dev examples/fastapi_stream.py
 
 # Once the server is up, try running the following script:
 # ```python
@@ -39,9 +41,57 @@ async def generate_response(prompt: str) -> AsyncGenerator[str, None]:
 
 @app.post("/")
 async def query(request: Request):
+    """
+    Example script to query the FastAPI server.
+    ```python
+    import httpx
+    url = "http://localhost:8000"
+    with httpx.stream("POST", url, json={"prompt": "why do stars twinkle?"}) as r:
+        for chunk in r.iter_raw():
+            print(chunk)
+    ```
+    """
     body = await request.json()
     prompt = body.get("prompt", "Write a haiku about trees")
     return StreamingResponse(generate_response(prompt), media_type="text/event-stream")
+
+
+class Person(BaseModel):
+    name: str = Field(description="Name of the person")
+    age: int = Field(description="Age of the person")
+
+
+class PersonModel(BaseModel):
+    person: Person
+
+
+async def generate_person() -> AsyncGenerator[str, None]:
+    sess = ChatLLMSession()
+    stream = sess.stream_model_async(
+        "Generate a random person with a unique name",
+        llm_options=default_options,
+        response_model=Person,
+    )
+    async for delta in async_pydantic_to_text_stream(stream, mode="delta"):
+        yield delta
+
+
+@app.post("/object")
+async def stream_object():
+    """
+    Example script to query the FastAPI server.
+    ```python
+    import httpx
+    url = "http://localhost:8000/object"
+    with httpx.stream("POST", url, json={}) as r:
+        for chunk in r.iter_raw():
+            print(chunk)
+    ```
+    """
+    response = StreamingResponse(generate_person())
+    # # Set custom headers if using Vercel AI SDK useObject hook
+    # response.headers["x-vercel-ai-data-stream"] = "v1"
+    return response
 
 
 if __name__ == "__main__":

--- a/examples/fastapi_stream.py
+++ b/examples/fastapi_stream.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
-from litellm import BaseModel, Field
+from pydantic import BaseModel, Field
 
 from simple_ai_agents.chat_session import ChatLLMSession
 from simple_ai_agents.models import LLMOptions

--- a/simple_ai_agents/utils.py
+++ b/simple_ai_agents/utils.py
@@ -186,7 +186,7 @@ def format_tool_schema(tools: list[Tool]):
 
 
 async def async_pydantic_to_text_stream(
-    stream: AsyncIterator[BaseModel], mode: Literal["full", "delta"] = "full"
+    stream: AsyncIterator[BaseModel], mode: Literal["full", "delta"] = "delta"
 ) -> AsyncIterator[str]:
     """
     Asynchronously converts a stream of Pydantic models to a stream of JSON strings,
@@ -224,7 +224,7 @@ async def async_pydantic_to_text_stream(
             # Determine the output based on the mode
             if mode == "full":
                 output = diff
-            else:  # mode == 'delta'
+            else:
                 output = diff[len(last_output) :]
 
             # Yield the output if it's not empty
@@ -239,7 +239,7 @@ async def async_pydantic_to_text_stream(
     if json_history and json_history[-1] != last_output:
         if mode == "full":
             yield json_history[-1]
-        else:  # mode == 'delta'
+        else:
             yield json_history[-1][len(last_output) :]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,166 @@
+from copy import deepcopy
+from typing import Any, Optional, Tuple, Type
+
+import pytest
+from pydantic import BaseModel, Field, create_model
+from pydantic.fields import FieldInfo
+
+from simple_ai_agents.utils import (
+    async_pydantic_to_text_stream,
+    pydantic_to_text_stream,
+)
+
+
+def partial(model: Type[BaseModel]):
+    def make_field_optional(
+        field: FieldInfo, default: Any = None
+    ) -> Tuple[Any, FieldInfo]:
+        new = deepcopy(field)
+        new.default = default
+        new.annotation = Optional[field.annotation]  # type: ignore
+        return new.annotation, new
+
+    return create_model(
+        f"Partial{model.__name__}",
+        __base__=model,
+        __module__=model.__module__,
+        **{
+            field_name: make_field_optional(field_info)
+            for field_name, field_info in model.model_fields.items()
+        },  # type: ignore
+    )  # type: ignore
+
+
+class Person(BaseModel):
+    name: str = Field(description="Name of the person")
+    age: int = Field(description="Age of the person")
+
+
+class PersonModel(BaseModel):
+    person: Person
+
+
+class MultiPersonModel(BaseModel):
+    persons: list[Person]
+
+
+PartialMultiPersonModel = partial(MultiPersonModel)
+PartialPerson = partial(Person)
+PartialPersonModel = partial(PersonModel)
+
+
+def test_pydantic_to_text_stream():
+    def sample_person_stream():
+        PartialPersonModel = partial(PersonModel)
+        PartialPerson = partial(Person)
+        yield PartialPersonModel(person=PartialPerson(name=None, age=None))
+        yield PartialPersonModel(person=PartialPerson(name="Alice", age=None))
+        yield PartialPersonModel(person=PartialPerson(name="Alice", age=None))
+        yield PartialPersonModel(person=PartialPerson(name="Alice", age=None))
+
+    for i, diff in enumerate(
+        pydantic_to_text_stream(sample_person_stream(), mode="full")
+    ):
+        if i == 0:
+            assert diff == '{"person": {"name": '
+        elif i == 1:
+            assert diff == '{"person": {"name": "Alice", "age": null}}'
+
+    for i, diff in enumerate(
+        pydantic_to_text_stream(sample_person_stream(), mode="delta")
+    ):
+        if i == 0:
+            assert diff == '{"person": {"name": '
+        elif i == 1:
+            assert diff == '"Alice", "age": null}}'
+
+
+@pytest.mark.asyncio
+async def test_async_pydantic_to_text_stream():
+    async def sample_person_stream():
+        PartialPersonModel = partial(PersonModel)
+        PartialPerson = partial(Person)
+        yield PartialPersonModel(person=PartialPerson(name=None, age=None))
+        yield PartialPersonModel(person=PartialPerson(name="Alice", age=None))
+        yield PartialPersonModel(person=PartialPerson(name="Alice", age=None))
+        yield PartialPersonModel(person=PartialPerson(name="Alice", age=None))
+
+    i = 0
+    async for diff in async_pydantic_to_text_stream(
+        sample_person_stream(), mode="full"
+    ):
+        if i == 0:
+            assert diff == '{"person": {"name": '
+        elif i == 1:
+            assert diff == '{"person": {"name": "Alice", "age": null}}'
+        i += 1
+
+    i = 0
+    async for diff in async_pydantic_to_text_stream(
+        sample_person_stream(), mode="delta"
+    ):
+        if i == 0:
+            assert diff == '{"person": {"name": '
+        elif i == 1:
+            assert diff == '"Alice", "age": null}}'
+        i += 1
+
+
+def test_pydantic_to_text_stream_list():
+    def sample_multi_person_stream():
+        yield PartialMultiPersonModel(persons=[PartialPerson(name="Alice", age=None)])
+        yield PartialMultiPersonModel(persons=[PartialPerson(name="Alice", age=None)])
+        yield PartialMultiPersonModel(
+            persons=[
+                PartialPerson(name="Alice", age=None),
+                PartialPerson(name=None, age=None),
+            ]
+        )
+        yield PartialMultiPersonModel(
+            persons=[
+                PartialPerson(name="Alice", age=None),
+                PartialPerson(name=None, age=None),
+            ]
+        )
+        yield PartialMultiPersonModel(
+            persons=[
+                PartialPerson(name="Alice", age=None),
+                PartialPerson(name="Bob", age=None),
+            ]
+        )
+        yield PartialMultiPersonModel(
+            persons=[
+                PartialPerson(name="Alice", age=None),
+                PartialPerson(name="Bob", age=30),
+            ]
+        )
+
+    for i, diff in enumerate(
+        pydantic_to_text_stream(sample_multi_person_stream(), mode="full")
+    ):
+        if i == 0:
+            assert diff == '{"persons": [{"name": "Alice", "age": null}'
+        elif i == 1:
+            assert diff == '{"persons": [{"name": "Alice", "age": null}, {"name": '
+        elif i == 2:
+            assert (
+                diff
+                == '{"persons": [{"name": "Alice", "age": null}, {"name": "Bob", "age": '
+            )
+        elif i == 3:
+            assert (
+                diff
+                == '{"persons": [{"name": "Alice", "age": null}, {"name": "Bob", "age": 30}]}'
+            )
+
+    for i, diff in enumerate(
+        pydantic_to_text_stream(sample_multi_person_stream(), mode="delta")
+    ):
+        if i == 0:
+            assert diff == '{"persons": [{"name": "Alice", "age": null}'
+        elif i == 1:
+            assert diff == ', {"name": '
+        elif i == 2:
+            assert diff == '"Bob", "age": '
+        elif i == 3:
+            assert diff == "30}]}"


### PR DESCRIPTION
Add util methods to stream from pydantic partials to incremental text chunks. This makes it easy to convert between the partial model output to text streams which Vercel useObject hook requires.